### PR TITLE
sigmastar: sc3336: record the orientation pCus_SetOrien was asked for

### DIFF
--- a/sigmastar/infinity6b0/sensor_sc3336_mipi.c
+++ b/sigmastar/infinity6b0/sensor_sc3336_mipi.c
@@ -554,18 +554,22 @@ static int pCus_SetOrien(ms_cus_sensor* handle, CUS_CAMSENSOR_ORIT orit)
     switch (orit) {
     case CUS_ORIT_M0F0:
         params->tMirror_reg[0].data = 0;
+        params->cur_orien = CUS_ORIT_M0F0;
         params->orient_dirty = true;
         break;
     case CUS_ORIT_M1F0:
         params->tMirror_reg[0].data = 6;
+        params->cur_orien = CUS_ORIT_M1F0;
         params->orient_dirty = true;
         break;
     case CUS_ORIT_M0F1:
         params->tMirror_reg[0].data = 0x60;
+        params->cur_orien = CUS_ORIT_M0F1;
         params->orient_dirty = true;
         break;
     case CUS_ORIT_M1F1:
         params->tMirror_reg[0].data = 0x66;
+        params->cur_orien = CUS_ORIT_M1F1;
         params->orient_dirty = true;
         break;
     }


### PR DESCRIPTION
`pCus_init_mipi2lane()` re-applies the stored orientation:

```c
pCus_SetOrien(handle, params->cur_orien);
```

But `pCus_SetOrien` only stages the mirror/flip value in `params->tMirror_reg` and raises the dirty flag — it never writes `cur_orien` back, so it stays at the `CUS_ORIT_M0F0` it is initialised to and init hands that identity value straight back.

`MI_SNR_SetOrien()` on an already-open sensor just stages the value for the next `pCus_AEStatusNotify(CUS_FRAME_ACTIVE)` flush, so a caller that sets orientation before enabling the sensor — the only order that works where orientation is fixed at bring-up — gets overwritten by the init call, and the first flush writes identity. Mirror and flip never reach the register.

`sensor_sc2335_mipi.c` and `sensor_sc2239_mipi.c` already assign `cur_orien` in each case; this makes sc3336 match.

Verified on an SSC333 + SC3336: before, `0x3221` stays `0x00` for any requested orientation; after, it tracks the request (`0x06` mirror, `0x60` flip, `0x66` both).

---

**Scope note:** an earlier revision of this PR made the same change across ten sigmastar drivers. Several of them do look like they have this bug, but SC3336 is the only part I can actually test, so it is now deliberately limited to that one driver. Happy to extend it if a maintainer wants the rest, and can share notes on which drivers looked affected — with the caveat that `sensor_sc850sl_mipi.c` has no `cur_orien` member at all (it would not build), and `sc223a`/`sc3338` have their init `pCus_SetOrien` call commented out, so the assignment would be a dead store there.
