### PR TITLE
sigmastar: sc450ai: write the model ID linear mode never set

### DIFF
--- a/sigmastar/infinity6c/sensor_sc450ai_mipi.c
+++ b/sigmastar/infinity6c/sensor_sc450ai_mipi.c
@@ -1845,7 +1845,7 @@ int cus_camsensor_init_handle(ms_cus_sensor* drv_handle)
     ////////////////////////////////////
     //    sensor model ID                           //
     ////////////////////////////////////
-    SENSOR_DMSG(handle->model_id, "sc450ai_MIPI");
+    sprintf(handle->model_id, "sc450ai_MIPI");
 
     ////////////////////////////////////
     //    sensor interface info       //


### PR DESCRIPTION
cus_camsensor_init_handle() sets the model ID with

    SENSOR_DMSG(handle->model_id, "sc450ai_MIPI");

SENSOR_DMSG is the debug-print macro, and at SENSOR_DBG == 0 -- the shipped
setting -- it expands to nothing, so model_id keeps the "" it was zeroed to.
The HDR SEF and LEF paths below already use sprintf and are unaffected; only
linear mode is left nameless.

MI_SNR_GetPlaneInfo() then reports an empty sensor name, and a userspace ISP
that names its per-sensor IQ tuning after the sensor has nothing to look up:
the tuning is silently never loaded and the picture stays on the CUS3A
defaults. Nothing returns an error, so it reads as a missing tuning file
rather than as a driver bug.

Verified on an SSC377D + SC450AI: before the change the sensor name comes
back empty and no tuning is loaded; after it the name is "sc450ai_MIPI", the
bin is found and MI_ISP_ApiCmdLoadBinFile accepts it, and the picture picks
up the tuning's colour and exposure.

The same typo is in infinity6b0/sensor_sc200ai_mipi.c and
infinity6e/sensor_gc2093_mipi.c, but this change is deliberately limited to
the one part I can actually test.
